### PR TITLE
fix(compat): Update way we register email tags

### DIFF
--- a/email-customization/conditional-email-based-on-amount.php
+++ b/email-customization/conditional-email-based-on-amount.php
@@ -2,47 +2,41 @@
 /**
  * Customize Give's Email Message based on Donation Amount
  *
- * This snippet checks for a donation amount to a certain form (ID 1329 in the example code), and then 
- * 1. sends a custom message for donations under ($)5 
+ * This snippet checks for a donation amount to a certain form (ID 1329 in the example code), and then
+ * 1. sends a custom message for donations under ($)5
  * 2. sends the default message for anything between ($)5 and ($)500
  * 3. sends a different custom message for donations over ($)500
- * 
+ *
  * NOTE: this snippet has not been tested thoroughly, especially alongside the Per Form Emails add-on. Use at your own risk.
  *
- * @param $email_body the default email body
- * @param $payment_id the donation ID
- * @param $payment_data the donation data (unused)
+ * @param string $email_body   The default email body.
+ * @param int    $payment_id   The donation ID.
+ * @param array  $payment_data The donation data (unused).
+ *
+ * @return string
  */
- 
 function my_custom_give_email_content( $email_body, $payment_id, $payment_data ) {
 
-	$amount = give_donation_amount( $payment_id );
+	$amount  = give_donation_amount( $payment_id );
 	$form_id = give_get_payment_form_id( $payment_id );
 
-	//Check if this payment's donation amount and form ID matches the donation form we want custom email body copy
-	if ( $amount < 5 && $form_id == '1329'  ) {
-		//Here you can output custom content or pull from custom post meta using get_post_meta, or use an ACF field, WordPress functions, etc.
-		//You can also use Give's email tags like {price}, {fullname}, etc.
+	// Check if this payment's donation amount and form ID matches the donation form we want custom email body copy.
+	if ( $amount < 5 && $form_id === '1329'  ) {
+		// Here you can output custom content or pull from custom post meta using get_post_meta, or use an ACF field, WordPress functions, etc.
+		// You can also use Give's email tags like {price}, {fullname}, etc.
 
 		$email_body = '<p>Hi {name}, </p>';
-		$email_body .= '<p> your donation to {form_title} was for {price} and that\'s great!</p>';
+		$email_body .= '<p>Your donation to {form_title} was for {price} and that\'s great!</p>';
 
-		//Make sure we return the new $email_body;
-		return $email_body;
+	} elseif ( $amount > 500 && $form_id === '1329'  ) {
 
-	} elseif ( $amount > 500 && $form_id == '1329'  ) {
-		//Here you can output custom content or pull from custom post meta using get_post_meta, or use an ACF field, WordPress functions, etc.
-		//You can also use Give's email tags like {price}, {fullname}, etc.
-
+		// Here you can output custom content or pull from custom post meta using get_post_meta, or use an ACF field, WordPress functions, etc.
+		// You can also use Give's email tags like {price}, {fullname}, etc.
 		$email_body = '<p>Hi {name}, You are a rock star! Thanks for such a large gift</p>';
-
-		//Make sure we return the new $email_body;
-		return $email_body;
-
-			//Be sure to return default email body if we don't make a match
-		} else {
-			return $email_body;
 	}
+
+	// Make sure we return the new $email_body;
+	return $email_body;
 }
 
 add_filter( 'give_donation_receipt', 'my_custom_give_email_content', 10, 3 );

--- a/email-customization/custom-email-headings.php
+++ b/email-customization/custom-email-headings.php
@@ -4,24 +4,23 @@
  *
  * Use this snippet to update the donation email's main headings; for instance "New Donation!", etc.
  *
- * @param $message
- * @param $email_obj
+ * @param string $heading Email Heading.
+ *
+ * @return string
  */
-function my_custom_give_email_headings( $message ) {
+function my_custom_give_email_headings( $heading ) {
 
-	switch ( $message ) {
+	switch ( $heading ) {
 
 		case 'New Donation!':
-			$message = 'Boom! New Donation';
+			$heading = __( 'Boom! New Donation', 'give-snippet' );
 			break;
 		case 'Donation Receipt':
-			$message = 'Your Donation Receipt';
+			$heading = __( 'Your Donation Receipt', 'give-snippet' );
 			break;
-
 	}
 
-	return $message;
+	return $heading;
 
 }
-
 add_filter( 'give_email_heading', 'my_custom_give_email_headings', 10, 1 );

--- a/email-customization/magic-tag.php
+++ b/email-customization/magic-tag.php
@@ -33,6 +33,8 @@ add_filter( 'give_email_tags', 'rum_wohh_add_magic_tag' );
  */
 function rum_wohh_get_wohh_magic_tag_data( $tag_args ) {
 
+	$payment_id = 0;
+
 	switch ( true ) {
 		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
 			$payment    = new Give_Payment( $tag_args['payment_id'] );

--- a/email-customization/magic-tag.php
+++ b/email-customization/magic-tag.php
@@ -46,7 +46,7 @@ function rum_wohh_get_wohh_magic_tag_data( $tag_args ) {
 	$output       = '';
 
 	// Check if this payment's donation form ID matches the donation form we want custom email body copy
-	if ( $form_id == '1650' ) {   // Online Donation form
+	if ( $form_id === '1650' ) {   // Online Donation form
 
 		// get the custom field data for this donation.
 		if ( ! empty( $meta_values['_give_payment_date'][0] ) ) {

--- a/email-customization/magic-tag.php
+++ b/email-customization/magic-tag.php
@@ -1,85 +1,72 @@
 <?php
-
-
 /**
  * Adds a Custom "Magic" Tag
  * This function creates a custom Give email template tag
  *
- * @param $payment_id
+ * @param array $email_tags List of email tags.
+ *
+ * @return array
  */
-function rum_wohh_add_magic_tag( $payment_id ) {
-	
-	give_add_email_tag( 'wohh_magic_tag', 'This tag can be used to output conditional content in email notifications', 'rum_wohh_get_wohh_magic_tag_data' );
+function rum_wohh_add_magic_tag( $email_tags ) {
+
+	$new_email_tag = array(
+		'tag'         => 'wohh_magic_tag',
+		'description' => esc_html__( 'This tag can be used to output conditional content in email notifications.', 'give-snippet' ),
+		'function'    => 'rum_wohh_get_wohh_magic_tag_data',
+		'context'     => 'general', // Context can be general, donor, form or donation
+	);
+
+	array_push( $email_tags, $new_email_tag );
+
+	return $email_tags;
 }
-add_action( 'give_add_email_tags', 'rum_wohh_add_magic_tag' );
-
-
-
+add_filter( 'give_email_tags', 'rum_wohh_add_magic_tag' );
 
 /**
  * Get Magic Tag Conditional Data
- * 
- * @description Example function that returns Custom field data if present, for any form ID
- * @param $payment_id
  *
- * @return string|void
+ * Example function that returns Custom field data if present, for any form ID
+ *
+ * @param array $tag_args Email Tag Arguments.
+ *
+ * @return string
  */
-function rum_wohh_get_wohh_magic_tag_data( $payment_id ) {
+function rum_wohh_get_wohh_magic_tag_data( $tag_args ) {
 
+	switch ( true ) {
+		case give_check_variable( $tag_args, 'isset', 0, 'payment_id' ):
+			$payment    = new Give_Payment( $tag_args['payment_id'] );
+			$payment_id = $payment->number;
+			break;
+	}
 
 	$form_id      = give_get_payment_form_id( $payment_id );
 	$payment_meta = give_get_payment_meta( $payment_id );
-	$meta_vals    = get_post_custom($payment_id);
+	$meta_values  = get_post_custom($payment_id);
 	$output       = '';
-
 
 	// Check if this payment's donation form ID matches the donation form we want custom email body copy
 	if ( $form_id == '1650' ) {   // Online Donation form
 
-
-		$donation_reason = '';
-
-
-		// get the custom field data for this donation
-		if ( isset($meta_vals['donation_reason']) ) {
-
-			$donation_reason = $meta_vals['donation_reason'][0];
-		}
-
-
-		if ( $donation_reason != '' ) {
-
-			$output = '<strong>Reason for Donation:</strong> ' . $donation_reason;
+		// get the custom field data for this donation.
+		if ( ! empty( $meta_values['_give_payment_date'][0] ) ) {
+			$output = sprintf(
+				'<strong>Payment Date for Donation:</strong> %1$s',
+				$meta_values['_give_payment_date'][0]
+			);
 		}
 	}
 
+	if ( $form_id === '1865' ) {   // Annual Memorial Walk Butterfly Campaign.
 
+		if ( ! empty( $meta_values['my_donation_is_in_memory_of'][0] ) ) {
 
-
-
-	// Check if this payment's donation form ID matches the donation form we want custom email body copy
-	if ( $form_id == '1865' ) {   // Annual Memorial Walk Butterfly Campaign
-
-
-
-		$in_memory_of = '';
-
-
-		// get the custom field data for this donation
-		if ( isset($meta_vals['my_donation_is_in_memory_of']) ) {
-
-			$in_memory_of = $meta_vals['my_donation_is_in_memory_of'][0];
-		}
-
-
-		if ( $in_memory_of != '' ) {
-
-			$output = '<strong>In Memory Of:</strong> ' . $in_memory_of;
+			$output = sprintf(
+				'<strong>In Memory Of:</strong> %1$s',
+				$meta_values['my_donation_is_in_memory_of'][0]
+			);
 		}
 	}
-
-
-
 
 	return $output;
 }


### PR DESCRIPTION
## Description
This PR resolves #54 

1. `class-donor-gratitude-email.php` - Already updated by @ravinderk 
2. `conditional-email-based-on-amount.php` - found working with Give Core 2.0+, But, improved code for better performance and compatibility
3. `custom-email-headings.php` - found working with Give Core 2.0+. But, improved variable terminology
4. `disable-donor-notification.php` - found working fine
5. `magic-tag.php` - implemented changes to the code for better compatibility and tested it and is now working fine.
6. `per-form-email-content.php` - I think this needs to be removed as per-form email functionality is included in Give Core 2.0. @ravinderk Let me know if I need to remove this snippet.
7. `remove-new-user-notification.php` - working fine