### PR TITLE
feat(snippet-library): add snippet to output list of closed forms. #78

### DIFF
--- a/custom-shortcodes/goal-achieved-form-list-shortcode.php
+++ b/custom-shortcodes/goal-achieved-form-list-shortcode.php
@@ -1,0 +1,55 @@
+<?php
+/**
+  *  SHORTCODE -- Goal Achieved Forms
+  *  Example: [give_goal_achieved_forms]
+  */
+function give_render_goal_achieved_forms_list() {
+
+	// Arguments to only fetch forms with goal enabled.
+	$form_args = array(
+		'post_type'      => 'give_forms',
+		'post_status'    => 'publish',
+		'posts_per_page' => get_option( 'posts_per_page' ),
+		'orderby'        => 'date',
+		'order'          => 'ASC',
+		'meta_key'       => '_give_goal_option',
+		'meta_value'     => 'enabled',
+	);
+
+	// Query to output donation forms.
+	$form_query = new WP_Query( $form_args );
+
+	if ( $form_query->have_posts() ) {
+		ob_start();
+
+		printf( '<table><thead><th>Form ID</th><th>Form Name</th></thead><tbody>' );
+
+		while ( $form_query->have_posts() ) {
+
+			$form_query->the_post();
+
+			$goal_stats = give_goal_progress_stats( get_the_ID() );
+
+			// Skip printing the form if the goal is not achieved.
+			if ( $goal_stats['raw_actual'] < $goal_stats['raw_goal'] ) {
+				continue;
+			}
+
+			// Print Form ID and Form Title with hyperink.
+			printf(
+				'<tr><td>%1$s</td><td><a href="%2$s">%3$s</a></td></tr>',
+				get_the_ID(),
+				get_the_permalink(),
+				get_the_title()
+			);
+		}
+
+		printf( '</tbody></table>' );
+
+		wp_reset_postdata();
+
+		return ob_get_clean();
+	}
+}
+
+add_shortcode( 'give_goal_achieved_forms', 'give_render_goal_achieved_forms_list' );


### PR DESCRIPTION
Closes #78 

## Description
The shortcode `[give_goal_achieved_forms]` renders a table of all the forms whose goals have completed.

## Screenshots
![goalcompleted](https://user-images.githubusercontent.com/17757960/43854735-6c78d108-9b61-11e8-8919-f22012aa7c04.png)
